### PR TITLE
Subaccount support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 qfex
 cli
 dist/
+.worktrees/
 
 # Go
 *.test

--- a/cmd/account.go
+++ b/cmd/account.go
@@ -207,13 +207,24 @@ var createSubaccountCmd = &cobra.Command{
 var transferSubaccountCmd = &cobra.Command{
 	Use:   "transfer",
 	Short: "Transfer funds between your accounts and subaccounts",
+	Long: `Transfer funds between your primary account and subaccounts.
+
+Use "primary" as the --from or --to value to refer to your primary account.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateSubaccountTransferInput(subaccountTransferFrom, subaccountTransferTo, subaccountTransferAmount); err != nil {
 			return err
 		}
+		from, err := resolveAccountID(subaccountTransferFrom)
+		if err != nil {
+			return err
+		}
+		to, err := resolveAccountID(subaccountTransferTo)
+		if err != nil {
+			return err
+		}
 		params := url.Values{}
-		params.Set("src_account_id", subaccountTransferFrom)
-		params.Set("dst_account_id", subaccountTransferTo)
+		params.Set("src_account_id", from)
+		params.Set("dst_account_id", to)
 		printResult(apiPostWithQueryAndAccountSelection("/user/transfer", params, map[string]any{
 			"amount": subaccountTransferAmount,
 		}, false))
@@ -307,9 +318,7 @@ func init() {
 }
 
 type subaccountsResponse struct {
-	Body struct {
-		AccountIDs []string `json:"account_ids"`
-	} `json:"body"`
+	AccountIDs []string `json:"account_ids"`
 }
 
 func fetchSubaccountIDs() ([]string, error) {
@@ -318,10 +327,10 @@ func fetchSubaccountIDs() ([]string, error) {
 	if err := json.Unmarshal(raw, &resp); err != nil {
 		return nil, fmt.Errorf("parse subaccounts response: %w", err)
 	}
-	if resp.Body.AccountIDs == nil {
+	if resp.AccountIDs == nil {
 		return []string{}, nil
 	}
-	return resp.Body.AccountIDs, nil
+	return resp.AccountIDs, nil
 }
 
 func currentSubaccountOutput() string {
@@ -356,4 +365,14 @@ func normalizeSelectedSubaccount(value string) (string, error) {
 		return "", nil
 	}
 	return selected, nil
+}
+
+func resolveAccountID(value string) (string, error) {
+	if strings.TrimSpace(strings.ToLower(value)) == "primary" {
+		if cfg == nil || cfg.UserID == "" {
+			return "", fmt.Errorf("primary account ID not available; please re-login with browser auth (qfex login)")
+		}
+		return cfg.UserID, nil
+	}
+	return value, nil
 }

--- a/cmd/account.go
+++ b/cmd/account.go
@@ -6,9 +6,11 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/qfex/cli/internal/config"
 	"github.com/qfex/cli/internal/protocol"
 )
 
@@ -22,11 +24,22 @@ var leverageCmd = &cobra.Command{
 	Short: "Leverage management commands",
 }
 
+var subaccountsCmd = &cobra.Command{
+	Use:   "subaccounts",
+	Short: "Manage account subaccounts",
+}
+
 var (
 	levSymbol   string
 	levLeverage float64
 	levLimit    int
 	levOffset   int
+)
+
+var (
+	subaccountTransferFrom   string
+	subaccountTransferTo     string
+	subaccountTransferAmount float64
 )
 
 var balanceCmd = &cobra.Command{
@@ -175,11 +188,90 @@ var cancelOnDisconnectCmd = &cobra.Command{
 	},
 }
 
+var listSubaccountsCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List your subaccounts",
+	Run: func(cmd *cobra.Command, args []string) {
+		printResult(apiGetWithAccountSelection("/user/subaccounts", nil, true, false))
+	},
+}
+
+var createSubaccountCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new subaccount",
+	Run: func(cmd *cobra.Command, args []string) {
+		printResult(apiPostWithQueryAndAccountSelection("/user/subaccounts", nil, struct{}{}, false))
+	},
+}
+
+var transferSubaccountCmd = &cobra.Command{
+	Use:   "transfer",
+	Short: "Transfer funds between your accounts and subaccounts",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateSubaccountTransferInput(subaccountTransferFrom, subaccountTransferTo, subaccountTransferAmount); err != nil {
+			return err
+		}
+		params := url.Values{}
+		params.Set("src_account_id", subaccountTransferFrom)
+		params.Set("dst_account_id", subaccountTransferTo)
+		printResult(apiPostWithQueryAndAccountSelection("/user/transfer", params, map[string]any{
+			"amount": subaccountTransferAmount,
+		}, false))
+		return nil
+	},
+}
+
+var currentSubaccountCmd = &cobra.Command{
+	Use:   "current",
+	Short: "Show the currently selected subaccount",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Print(currentSubaccountOutput())
+	},
+}
+
+var selectSubaccountCmd = &cobra.Command{
+	Use:   "select <account-id|primary>",
+	Short: "Select the active subaccount and restart the daemon if needed",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		selected, err := normalizeSelectedSubaccount(args[0])
+		if err != nil {
+			return err
+		}
+
+		if selected != "" {
+			subaccounts, err := fetchSubaccountIDs()
+			if err != nil {
+				return err
+			}
+			if err := validateSelectableSubaccount(selected, subaccounts); err != nil {
+				return err
+			}
+		}
+
+		if cfg.SelectedSubaccount == selected {
+			fmt.Print(currentSubaccountOutput())
+			return nil
+		}
+
+		cfg.SelectedSubaccount = selected
+		if err := config.Save(cfg); err != nil {
+			return fmt.Errorf("saving config: %w", err)
+		}
+		if err := restartDaemonIfRunning(cmd); err != nil {
+			return err
+		}
+		fmt.Print(currentSubaccountOutput())
+		return nil
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(accountCmd)
 	accountCmd.AddCommand(balanceCmd)
 	accountCmd.AddCommand(depositCmd)
 	accountCmd.AddCommand(leverageCmd)
+	accountCmd.AddCommand(subaccountsCmd)
 	accountCmd.AddCommand(cancelOnDisconnectCmd)
 	accountCmd.AddCommand(feesCmd)
 	accountCmd.AddCommand(pnlCmd)
@@ -187,6 +279,11 @@ func init() {
 	leverageCmd.AddCommand(getLeverageCmd)
 	leverageCmd.AddCommand(setLeverageCmd)
 	leverageCmd.AddCommand(getAvailableLeverageCmd)
+	subaccountsCmd.AddCommand(listSubaccountsCmd)
+	subaccountsCmd.AddCommand(createSubaccountCmd)
+	subaccountsCmd.AddCommand(transferSubaccountCmd)
+	subaccountsCmd.AddCommand(currentSubaccountCmd)
+	subaccountsCmd.AddCommand(selectSubaccountCmd)
 
 	getLeverageCmd.Flags().IntVar(&levLimit, "limit", 50, "Maximum number of results")
 	getLeverageCmd.Flags().IntVar(&levOffset, "offset", 0, "Pagination offset")
@@ -203,4 +300,60 @@ func init() {
 	pnlCmd.Flags().StringVar(&pnlStart, "start", "", "Start time in ISO 8601")
 	pnlCmd.Flags().StringVar(&pnlEnd, "end", "", "End time in ISO 8601")
 	pnlCmd.Flags().Int64Var(&pnlLimitHours, "limit-hours", 168, "Hours of history (default 168, max 2160)")
+
+	transferSubaccountCmd.Flags().StringVar(&subaccountTransferFrom, "from", "", "Source account ID")
+	transferSubaccountCmd.Flags().StringVar(&subaccountTransferTo, "to", "", "Destination account ID")
+	transferSubaccountCmd.Flags().Float64Var(&subaccountTransferAmount, "amount", 0, "Amount to transfer")
+}
+
+type subaccountsResponse struct {
+	Body struct {
+		AccountIDs []string `json:"account_ids"`
+	} `json:"body"`
+}
+
+func fetchSubaccountIDs() ([]string, error) {
+	raw := apiGetWithAccountSelection("/user/subaccounts", nil, true, false)
+	var resp subaccountsResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("parse subaccounts response: %w", err)
+	}
+	if resp.Body.AccountIDs == nil {
+		return []string{}, nil
+	}
+	return resp.Body.AccountIDs, nil
+}
+
+func currentSubaccountOutput() string {
+	if cfg == nil || !cfg.HasSelectedSubaccount() {
+		return "primary\n"
+	}
+	return cfg.SelectedSubaccount + "\n"
+}
+
+func validateSubaccountTransferInput(from, to string, amount float64) error {
+	if strings.TrimSpace(from) == "" || strings.TrimSpace(to) == "" || amount <= 0 {
+		return fmt.Errorf("required: --from, --to, --amount")
+	}
+	return nil
+}
+
+func validateSelectableSubaccount(selected string, subaccounts []string) error {
+	for _, subaccount := range subaccounts {
+		if subaccount == selected {
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown subaccount: %s", selected)
+}
+
+func normalizeSelectedSubaccount(value string) (string, error) {
+	selected := strings.TrimSpace(value)
+	if selected == "" {
+		return "", fmt.Errorf("account ID cannot be empty")
+	}
+	if selected == "primary" {
+		return "", nil
+	}
+	return selected, nil
 }

--- a/cmd/account_test.go
+++ b/cmd/account_test.go
@@ -34,3 +34,45 @@ func TestValidateSelectableSubaccountRejectsUnknownID(t *testing.T) {
 		t.Fatalf("validateSelectableSubaccount() error = nil, want error")
 	}
 }
+
+func TestResolveAccountIDPrimaryReturnsUserID(t *testing.T) {
+	cfg = &config.Config{UserID: "user-abc-123"}
+	got, err := resolveAccountID("primary")
+	if err != nil {
+		t.Fatalf("resolveAccountID(\"primary\") error = %v", err)
+	}
+	if got != "user-abc-123" {
+		t.Fatalf("resolveAccountID(\"primary\") = %q, want %q", got, "user-abc-123")
+	}
+}
+
+func TestResolveAccountIDPrimaryCaseInsensitive(t *testing.T) {
+	cfg = &config.Config{UserID: "user-abc-123"}
+	got, err := resolveAccountID("Primary")
+	if err != nil {
+		t.Fatalf("resolveAccountID(\"Primary\") error = %v", err)
+	}
+	if got != "user-abc-123" {
+		t.Fatalf("resolveAccountID(\"Primary\") = %q, want %q", got, "user-abc-123")
+	}
+}
+
+func TestResolveAccountIDPrimaryErrorsWhenNoUserID(t *testing.T) {
+	cfg = &config.Config{}
+	_, err := resolveAccountID("primary")
+	if err == nil {
+		t.Fatalf("resolveAccountID(\"primary\") error = nil, want error")
+	}
+}
+
+func TestResolveAccountIDPassesThroughUUID(t *testing.T) {
+	cfg = &config.Config{}
+	id := "f0ed8fbd-5a60-46fe-b112-e8887ea02824"
+	got, err := resolveAccountID(id)
+	if err != nil {
+		t.Fatalf("resolveAccountID(%q) error = %v", id, err)
+	}
+	if got != id {
+		t.Fatalf("resolveAccountID(%q) = %q, want %q", id, got, id)
+	}
+}

--- a/cmd/account_test.go
+++ b/cmd/account_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/qfex/cli/internal/config"
+)
+
+func TestCurrentSubaccountOutputPrimaryWhenUnset(t *testing.T) {
+	cfg = &config.Config{}
+
+	if got := currentSubaccountOutput(); got != "primary\n" {
+		t.Fatalf("currentSubaccountOutput() = %q, want %q", got, "primary\n")
+	}
+}
+
+func TestCurrentSubaccountOutputSelectedSubaccount(t *testing.T) {
+	cfg = &config.Config{SelectedSubaccount: "sub-123"}
+
+	if got := currentSubaccountOutput(); got != "sub-123\n" {
+		t.Fatalf("currentSubaccountOutput() = %q, want %q", got, "sub-123\n")
+	}
+}
+
+func TestValidateSubaccountTransferInputRequiresFromToAndAmount(t *testing.T) {
+	if err := validateSubaccountTransferInput("", "", 0); err == nil {
+		t.Fatalf("validateSubaccountTransferInput() error = nil, want error")
+	}
+}
+
+func TestValidateSelectableSubaccountRejectsUnknownID(t *testing.T) {
+	err := validateSelectableSubaccount("sub-404", []string{"sub-1", "sub-2"})
+	if err == nil {
+		t.Fatalf("validateSelectableSubaccount() error = nil, want error")
+	}
+}

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -188,6 +188,13 @@ func runDaemonRestart(cmd *cobra.Command, args []string) error {
 	return runDaemonStart(cmd, args)
 }
 
+func restartDaemonIfRunning(cmd *cobra.Command) error {
+	if !daemonIsRunning() {
+		return nil
+	}
+	return daemonRestart(cmd, nil)
+}
+
 func runDaemonForeground(cmd *cobra.Command, args []string) error {
 	d := daemon.New(cfg, config.SocketPath())
 	ctx := context.Background()

--- a/cmd/daemon_test.go
+++ b/cmd/daemon_test.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRestartDaemonIfRunningStopsAndStartsWhenRunning(t *testing.T) {
+	oldIsRunning := daemonIsRunning
+	oldRestart := daemonRestart
+	t.Cleanup(func() {
+		daemonIsRunning = oldIsRunning
+		daemonRestart = oldRestart
+	})
+
+	called := false
+	daemonIsRunning = func() bool { return true }
+	daemonRestart = func(cmd *cobra.Command, args []string) error {
+		called = true
+		return nil
+	}
+
+	if err := restartDaemonIfRunning(&cobra.Command{}); err != nil {
+		t.Fatalf("restartDaemonIfRunning() error = %v", err)
+	}
+
+	if !called {
+		t.Fatalf("daemon restart was not called")
+	}
+}
+
+func TestRestartDaemonIfRunningNoopsWhenDaemonNotRunning(t *testing.T) {
+	oldIsRunning := daemonIsRunning
+	oldRestart := daemonRestart
+	t.Cleanup(func() {
+		daemonIsRunning = oldIsRunning
+		daemonRestart = oldRestart
+	})
+
+	daemonIsRunning = func() bool { return false }
+	daemonRestart = func(cmd *cobra.Command, args []string) error {
+		return errors.New("should not be called")
+	}
+
+	if err := restartDaemonIfRunning(&cobra.Command{}); err != nil {
+		t.Fatalf("restartDaemonIfRunning() error = %v", err)
+	}
+}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -84,6 +86,9 @@ func runBrowserLogin(cmd *cobra.Command, args []string) error {
 	} else {
 		cfg.Env = ""
 	}
+	if err := applyLoginSubaccountSelection(cmd, reader, os.Stdout); err != nil {
+		return err
+	}
 
 	if err := config.Save(cfg); err != nil {
 		return fmt.Errorf("saving config: %w", err)
@@ -145,6 +150,9 @@ func runAPIKeyLogin(cmd *cobra.Command, args []string) error {
 	} else {
 		cfg.Env = ""
 	}
+	if err := applyLoginSubaccountSelection(cmd, reader, os.Stdout); err != nil {
+		return err
+	}
 	if err := config.Save(cfg); err != nil {
 		return fmt.Errorf("saving config: %w", err)
 	}
@@ -163,6 +171,7 @@ var logoutCmd = &cobra.Command{
 		cfg.SecretKey = ""
 		cfg.AccessToken = ""
 		cfg.RefreshToken = ""
+		cfg.SelectedSubaccount = ""
 		if err := config.Save(cfg); err != nil {
 			return fmt.Errorf("saving config: %w", err)
 		}
@@ -176,4 +185,64 @@ func init() {
 	rootCmd.AddCommand(logoutCmd)
 
 	loginCmd.Flags().BoolVar(&loginAPIKey, "api-key", false, "Use API key login (public key + secret key) instead of browser")
+}
+
+func applyLoginSubaccountSelection(cmd *cobra.Command, in io.Reader, out io.Writer) error {
+	subaccounts, err := fetchSubaccountIDs()
+	if err != nil {
+		return err
+	}
+	return handlePostLoginSubaccountSelection(cmd, in, out, subaccounts)
+}
+
+func handlePostLoginSubaccountSelection(cmd *cobra.Command, in io.Reader, out io.Writer, subaccounts []string) error {
+	selected, err := chooseSelectedSubaccount(in, out, subaccounts)
+	if err != nil {
+		return err
+	}
+	cfg.SelectedSubaccount = selected
+	return nil
+}
+
+func chooseSelectedSubaccount(in io.Reader, out io.Writer, subaccounts []string) (string, error) {
+	if len(subaccounts) == 0 {
+		return "", nil
+	}
+
+	if _, err := fmt.Fprintln(out, "Select active account:"); err != nil {
+		return "", err
+	}
+	if _, err := fmt.Fprintln(out, "  0) primary"); err != nil {
+		return "", err
+	}
+	for i, subaccount := range subaccounts {
+		if _, err := fmt.Fprintf(out, "  %d) %s\n", i+1, subaccount); err != nil {
+			return "", err
+		}
+	}
+	if _, err := fmt.Fprint(out, "Choice [0]: "); err != nil {
+		return "", err
+	}
+
+	reader := bufio.NewReader(in)
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return "", nil
+	}
+
+	choice, err := strconv.Atoi(line)
+	if err != nil {
+		return "", fmt.Errorf("invalid selection: %s", line)
+	}
+	if choice == 0 {
+		return "", nil
+	}
+	if choice < 0 || choice > len(subaccounts) {
+		return "", fmt.Errorf("selection out of range: %d", choice)
+	}
+	return subaccounts[choice-1], nil
 }

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -78,7 +78,7 @@ func runBrowserLogin(cmd *cobra.Command, args []string) error {
 
 	cfg.AccessToken = tokens.AccessToken
 	cfg.RefreshToken = tokens.RefreshToken
-	// Clear any stale API key credentials.
+	cfg.UserID = oauth.SubFromToken(tokens.AccessToken)
 	cfg.PublicKey = ""
 	cfg.SecretKey = ""
 	if env == "uat" {
@@ -142,9 +142,9 @@ func runAPIKeyLogin(cmd *cobra.Command, args []string) error {
 
 	cfg.PublicKey = publicKey
 	cfg.SecretKey = secretKey
-	// Clear any stale JWT credentials.
 	cfg.AccessToken = ""
 	cfg.RefreshToken = ""
+	cfg.UserID = ""
 	if env == "uat" {
 		cfg.Env = "uat"
 	} else {
@@ -171,6 +171,7 @@ var logoutCmd = &cobra.Command{
 		cfg.SecretKey = ""
 		cfg.AccessToken = ""
 		cfg.RefreshToken = ""
+		cfg.UserID = ""
 		cfg.SelectedSubaccount = ""
 		if err := config.Save(cfg); err != nil {
 			return fmt.Errorf("saving config: %w", err)

--- a/cmd/login_test.go
+++ b/cmd/login_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/qfex/cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func TestHandlePostLoginSubaccountSelectionWithNoSubaccountsClearsSelection(t *testing.T) {
+	oldIsRunning := daemonIsRunning
+	oldRestart := daemonRestart
+	t.Cleanup(func() {
+		daemonIsRunning = oldIsRunning
+		daemonRestart = oldRestart
+	})
+	daemonIsRunning = func() bool { return false }
+	daemonRestart = func(cmd *cobra.Command, args []string) error { return nil }
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cfg = &config.Config{SelectedSubaccount: "old-sub"}
+
+	if err := handlePostLoginSubaccountSelection(&cobra.Command{}, strings.NewReader(""), io.Discard, nil); err != nil {
+		t.Fatalf("handlePostLoginSubaccountSelection() error = %v", err)
+	}
+
+	if got := cfg.SelectedSubaccount; got != "" {
+		t.Fatalf("SelectedSubaccount = %q, want empty", got)
+	}
+}
+
+func TestHandlePostLoginSubaccountSelectionSetsSelectedSubaccountWhenUserChoosesOne(t *testing.T) {
+	oldIsRunning := daemonIsRunning
+	oldRestart := daemonRestart
+	t.Cleanup(func() {
+		daemonIsRunning = oldIsRunning
+		daemonRestart = oldRestart
+	})
+	daemonIsRunning = func() bool { return false }
+	daemonRestart = func(cmd *cobra.Command, args []string) error { return nil }
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cfg = &config.Config{}
+
+	if err := handlePostLoginSubaccountSelection(&cobra.Command{}, strings.NewReader("2\n"), io.Discard, []string{"sub-1", "sub-2"}); err != nil {
+		t.Fatalf("handlePostLoginSubaccountSelection() error = %v", err)
+	}
+
+	if got := cfg.SelectedSubaccount; got != "sub-2" {
+		t.Fatalf("SelectedSubaccount = %q, want %q", got, "sub-2")
+	}
+}
+
+func TestHandlePostLoginSubaccountSelectionLeavesSelectionUnsetWhenUserKeepsPrimary(t *testing.T) {
+	oldIsRunning := daemonIsRunning
+	oldRestart := daemonRestart
+	t.Cleanup(func() {
+		daemonIsRunning = oldIsRunning
+		daemonRestart = oldRestart
+	})
+	daemonIsRunning = func() bool { return false }
+	daemonRestart = func(cmd *cobra.Command, args []string) error { return nil }
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cfg = &config.Config{}
+
+	if err := handlePostLoginSubaccountSelection(&cobra.Command{}, strings.NewReader("0\n"), io.Discard, []string{"sub-1", "sub-2"}); err != nil {
+		t.Fatalf("handlePostLoginSubaccountSelection() error = %v", err)
+	}
+
+	if got := cfg.SelectedSubaccount; got != "" {
+		t.Fatalf("SelectedSubaccount = %q, want empty", got)
+	}
+}

--- a/cmd/rest.go
+++ b/cmd/rest.go
@@ -19,6 +19,10 @@ import (
 
 // apiGetURL makes a GET request to an arbitrary URL and returns the parsed JSON body.
 func apiGetURL(u string, needsAuth bool) json.RawMessage {
+	return apiGetURLWithAccountSelection(u, needsAuth, true)
+}
+
+func apiGetURLWithAccountSelection(u string, needsAuth bool, includeRequestedAccount bool) json.RawMessage {
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -26,7 +30,7 @@ func apiGetURL(u string, needsAuth bool) json.RawMessage {
 	}
 	req.Header.Set("Accept", "application/json")
 	if needsAuth {
-		setAuthHeaders(req)
+		setAuthHeaders(req, includeRequestedAccount)
 	}
 	return doRequest(req)
 }
@@ -34,6 +38,10 @@ func apiGetURL(u string, needsAuth bool) json.RawMessage {
 // apiGet makes a GET request to the REST API and returns the parsed JSON body.
 // If needsAuth is true, HMAC auth headers are added.
 func apiGet(path string, params url.Values, needsAuth bool) json.RawMessage {
+	return apiGetWithAccountSelection(path, params, needsAuth, true)
+}
+
+func apiGetWithAccountSelection(path string, params url.Values, needsAuth bool, includeRequestedAccount bool) json.RawMessage {
 	u := cfg.APIURL() + path
 	if len(params) > 0 {
 		u += "?" + params.Encode()
@@ -45,27 +53,43 @@ func apiGet(path string, params url.Values, needsAuth bool) json.RawMessage {
 	}
 	req.Header.Set("Accept", "application/json")
 	if needsAuth {
-		setAuthHeaders(req)
+		setAuthHeaders(req, includeRequestedAccount)
 	}
 	return doRequest(req)
 }
 
 // apiPost makes an authenticated POST request and returns the parsed JSON body.
 func apiPost(path string, payload any) json.RawMessage {
+	return apiPostWithQuery(path, nil, payload)
+}
+
+func apiPostWithQuery(path string, params url.Values, payload any) json.RawMessage {
+	return apiPostWithQueryAndAccountSelection(path, params, payload, true)
+}
+
+func apiPostWithQueryAndAccountSelection(path string, params url.Values, payload any, includeRequestedAccount bool) json.RawMessage {
 	b, _ := json.Marshal(payload)
-	req, err := http.NewRequest(http.MethodPost, cfg.APIURL()+path, bytes.NewReader(b))
+	u := cfg.APIURL() + path
+	if len(params) > 0 {
+		u += "?" + params.Encode()
+	}
+	req, err := http.NewRequest(http.MethodPost, u, bytes.NewReader(b))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	setAuthHeaders(req)
+	setAuthHeaders(req, includeRequestedAccount)
 	return doRequest(req)
 }
 
 // apiStream makes a GET request and streams the response body to stdout (for CSV endpoints).
 func apiStream(path string, params url.Values, needsAuth bool) {
+	apiStreamWithAccountSelection(path, params, needsAuth, true)
+}
+
+func apiStreamWithAccountSelection(path string, params url.Values, needsAuth bool, includeRequestedAccount bool) {
 	u := cfg.APIURL() + path
 	if len(params) > 0 {
 		u += "?" + params.Encode()
@@ -77,7 +101,7 @@ func apiStream(path string, params url.Values, needsAuth bool) {
 	}
 	req.Header.Set("User-Agent", build.UserAgent())
 	if needsAuth {
-		setAuthHeaders(req)
+		setAuthHeaders(req, includeRequestedAccount)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -93,7 +117,7 @@ func apiStream(path string, params url.Values, needsAuth bool) {
 	io.Copy(os.Stdout, resp.Body)
 }
 
-func setAuthHeaders(req *http.Request) {
+func setAuthHeaders(req *http.Request, includeRequestedAccount bool) {
 	if cfg.HasJWT() {
 		if oauth.IsTokenExpired(cfg.AccessToken) {
 			if err := refreshAndSave(); err != nil {
@@ -101,6 +125,7 @@ func setAuthHeaders(req *http.Request) {
 			}
 		}
 		req.Header.Set("Authorization", "Bearer "+cfg.AccessToken)
+		setRequestedAccountHeader(req, includeRequestedAccount)
 		return
 	}
 	headers, err := auth.RESTHeaders(cfg.PublicKey, cfg.SecretKey)
@@ -110,6 +135,13 @@ func setAuthHeaders(req *http.Request) {
 	}
 	for k, v := range headers {
 		req.Header.Set(k, v)
+	}
+	setRequestedAccountHeader(req, includeRequestedAccount)
+}
+
+func setRequestedAccountHeader(req *http.Request, includeRequestedAccount bool) {
+	if includeRequestedAccount && cfg != nil && cfg.HasSelectedSubaccount() {
+		req.Header.Set("x-qfex-requested-account-id", cfg.SelectedSubaccount)
 	}
 }
 

--- a/cmd/rest_test.go
+++ b/cmd/rest_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/qfex/cli/internal/config"
+)
+
+func TestSetAuthHeadersAddsRequestedAccountIDWhenSelectedSubaccountPresent(t *testing.T) {
+	cfg = &config.Config{
+		AccessToken:        testJWT(t, time.Now().Add(time.Hour).Unix()),
+		SelectedSubaccount: "sub-123",
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+
+	setAuthHeaders(req, true)
+
+	if got := req.Header.Get("x-qfex-requested-account-id"); got != "sub-123" {
+		t.Fatalf("requested account header = %q, want %q", got, "sub-123")
+	}
+}
+
+func TestSetAuthHeadersOmitsRequestedAccountIDWhenNoSelection(t *testing.T) {
+	cfg = &config.Config{
+		AccessToken: testJWT(t, time.Now().Add(time.Hour).Unix()),
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+
+	setAuthHeaders(req, true)
+
+	if got := req.Header.Get("x-qfex-requested-account-id"); got != "" {
+		t.Fatalf("requested account header = %q, want empty", got)
+	}
+}
+
+func TestSetAuthHeadersOmitsRequestedAccountIDWhenSelectionDisabled(t *testing.T) {
+	cfg = &config.Config{
+		AccessToken:        testJWT(t, time.Now().Add(time.Hour).Unix()),
+		SelectedSubaccount: "sub-123",
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+
+	setAuthHeaders(req, false)
+
+	if got := req.Header.Get("x-qfex-requested-account-id"); got != "" {
+		t.Fatalf("requested account header = %q, want empty", got)
+	}
+}
+
+func testJWT(t *testing.T, exp int64) string {
+	t.Helper()
+
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payloadBytes, err := json.Marshal(map[string]any{"exp": exp})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	payload := base64.RawURLEncoding.EncodeToString(payloadBytes)
+	return header + "." + payload + ".signature"
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,13 @@ var (
 	jsonOutput bool
 )
 
+var (
+	daemonIsRunning = func() bool {
+		return cli != nil && cli.IsRunning()
+	}
+	daemonRestart = runDaemonRestart
+)
+
 var rootCmd = &cobra.Command{
 	Use:   "qfex",
 	Short: "QFEX trading CLI",
@@ -136,7 +143,7 @@ func sendAndPrint(cmd string, params any) {
 
 // requireDaemon ensures the daemon is running, starting it automatically if needed.
 func requireDaemon() {
-	if cli.IsRunning() {
+	if daemonIsRunning() {
 		return
 	}
 	fmt.Fprintln(os.Stderr, "Starting daemon...")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,10 @@ type Config struct {
 	// UAT is identical to prod but uses qfex.io instead of qfex.com.
 	Env string `yaml:"env,omitempty"`
 
+	// UserID is the primary account ID (JWT "sub" claim), stored at login time.
+	// Used to resolve "primary" in transfer --from/--to flags.
+	UserID string `yaml:"user_id,omitempty"`
+
 	// SelectedSubaccount stores the active child account to use for authenticated
 	// REST requests and daemon trade auth. Empty means use the primary account.
 	SelectedSubaccount string `yaml:"selected_subaccount,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -20,6 +21,10 @@ type Config struct {
 	// Env selects the target environment: "prod" (default) or "uat".
 	// UAT is identical to prod but uses qfex.io instead of qfex.com.
 	Env string `yaml:"env,omitempty"`
+
+	// SelectedSubaccount stores the active child account to use for authenticated
+	// REST requests and daemon trade auth. Empty means use the primary account.
+	SelectedSubaccount string `yaml:"selected_subaccount,omitempty"`
 
 	// Optional per-URL overrides (take precedence over Env).
 	TradeWSURL string `yaml:"trade_ws_url,omitempty"`
@@ -66,6 +71,10 @@ func (c *Config) HasCredentials() bool {
 // HasJWT returns true when a JWT access token is stored (browser login).
 func (c *Config) HasJWT() bool {
 	return c.AccessToken != ""
+}
+
+func (c *Config) HasSelectedSubaccount() bool {
+	return strings.TrimSpace(c.SelectedSubaccount) != ""
 }
 
 func Dir() string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveAndLoadSelectedSubaccount(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	cfg := &Config{SelectedSubaccount: "11111111-1111-1111-1111-111111111111"}
+	if err := Save(cfg); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	got, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if got.SelectedSubaccount != cfg.SelectedSubaccount {
+		t.Fatalf("SelectedSubaccount = %q, want %q", got.SelectedSubaccount, cfg.SelectedSubaccount)
+	}
+}
+
+func TestSelectedSubaccountUnsetPreservesZeroValue(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	if err := Save(&Config{}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	got, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if got.SelectedSubaccount != "" {
+		t.Fatalf("SelectedSubaccount = %q, want empty", got.SelectedSubaccount)
+	}
+
+	if _, err := os.Stat(filepath.Join(tmp, "qfex", "config.yaml")); err != nil {
+		t.Fatalf("config file not written: %v", err)
+	}
+}

--- a/internal/daemon/trade_ws.go
+++ b/internal/daemon/trade_ws.go
@@ -224,6 +224,8 @@ func (t *TradeWS) sendAuth(conn *websocket.Conn) error {
 	if err != nil {
 		return err
 	}
+	raw, _ := json.Marshal(msg)
+	t.log.Printf("Trade WS: sending auth: %s", raw)
 	return conn.WriteJSON(msg)
 }
 

--- a/internal/daemon/trade_ws.go
+++ b/internal/daemon/trade_ws.go
@@ -28,51 +28,51 @@ type tradeMessage struct {
 	Contents     json.RawMessage `json:"contents,omitempty"`
 
 	// Direct response keys
-	Authenticated              *bool           `json:"authenticated,omitempty"`
-	Subscribed                 *string         `json:"subscribed,omitempty"`
-	Unsubscribed               *string         `json:"unsubscribed,omitempty"`
-	OrderResponse              json.RawMessage `json:"order_response,omitempty"`
-	FillResponse               json.RawMessage `json:"fill_response,omitempty"`
-	AllOrdersResponse          json.RawMessage `json:"all_orders_response,omitempty"`
-	UserTradesResponse         json.RawMessage `json:"user_trades_response,omitempty"`
-	UserLeverageResponse       json.RawMessage `json:"user_leverage_response,omitempty"`
-	AvailableLeverageResponse  json.RawMessage `json:"available_leverage_levels_response,omitempty"`
-	PositionResponse           json.RawMessage `json:"position_response,omitempty"`
-	BalanceResponse            json.RawMessage `json:"balance_response,omitempty"`
-	StopOrderResponse          json.RawMessage `json:"stop_order_response,omitempty"`
-	TwapResponse               json.RawMessage `json:"twap_response,omitempty"`
-	Ack                        json.RawMessage `json:"ack,omitempty"`
-	Err                        json.RawMessage `json:"err,omitempty"`
+	Authenticated             *bool           `json:"authenticated,omitempty"`
+	Subscribed                *string         `json:"subscribed,omitempty"`
+	Unsubscribed              *string         `json:"unsubscribed,omitempty"`
+	OrderResponse             json.RawMessage `json:"order_response,omitempty"`
+	FillResponse              json.RawMessage `json:"fill_response,omitempty"`
+	AllOrdersResponse         json.RawMessage `json:"all_orders_response,omitempty"`
+	UserTradesResponse        json.RawMessage `json:"user_trades_response,omitempty"`
+	UserLeverageResponse      json.RawMessage `json:"user_leverage_response,omitempty"`
+	AvailableLeverageResponse json.RawMessage `json:"available_leverage_levels_response,omitempty"`
+	PositionResponse          json.RawMessage `json:"position_response,omitempty"`
+	BalanceResponse           json.RawMessage `json:"balance_response,omitempty"`
+	StopOrderResponse         json.RawMessage `json:"stop_order_response,omitempty"`
+	TwapResponse              json.RawMessage `json:"twap_response,omitempty"`
+	Ack                       json.RawMessage `json:"ack,omitempty"`
+	Err                       json.RawMessage `json:"err,omitempty"`
 }
 
 // terminalOrderStatuses are order statuses that are final (not ACK).
 var terminalOrderStatuses = map[string]bool{
-	"FILLED":                              true,
-	"CANCELLED":                           true,
-	"CANCELLED_STP":                       true,
-	"REJECTED":                            true,
-	"NO_SUCH_ORDER":                       true,
-	"INVALID_ORDER_TYPE":                  true,
-	"BAD_SYMBOL":                          true,
-	"PRICE_LESS_THAN_MIN_PRICE":           true,
-	"PRICE_GREATER_THAN_MAX_PRICE":        true,
-	"CANNOT_MODIFY_PARTIAL_FILL":          true,
-	"FAILED_MARGIN_CHECK":                 true,
-	"INVALID_TICK_SIZE_PRECISION_PRICE":   true,
+	"FILLED":                               true,
+	"CANCELLED":                            true,
+	"CANCELLED_STP":                        true,
+	"REJECTED":                             true,
+	"NO_SUCH_ORDER":                        true,
+	"INVALID_ORDER_TYPE":                   true,
+	"BAD_SYMBOL":                           true,
+	"PRICE_LESS_THAN_MIN_PRICE":            true,
+	"PRICE_GREATER_THAN_MAX_PRICE":         true,
+	"CANNOT_MODIFY_PARTIAL_FILL":           true,
+	"FAILED_MARGIN_CHECK":                  true,
+	"INVALID_TICK_SIZE_PRECISION_PRICE":    true,
 	"INVALID_TICK_SIZE_PRECISION_QUANTITY": true,
-	"QUANTITY_LESS_THAN_MIN_QUANTITY":     true,
-	"QUANTITY_GREATER_THAN_MAX_QUANTITY":  true,
-	"INVALID_TIME_IN_FORCE":               true,
-	"REJECTED_WOULD_BREACH_MAX_NOTIONAL":  true,
-	"CANNOT_MODIFY_NO_SUCH_ORDER":         true,
-	"REJECTED_MARKET_CLOSED":              true,
-	"REJECTED_FAILED_TO_PROCESS":          true,
-	"INVALID_TAKEPROFIT_PRICE":            true,
-	"INVALID_STOPLOSS_PRICE":              true,
-	"RATE_LIMITED":                        true,
-	"REJECTED_TOO_MANY_OPEN_ORDERS":       true,
-	"REJECTED_OPEN_INTEREST_LIMIT":        true,
-	"MODIFIED":                            true,
+	"QUANTITY_LESS_THAN_MIN_QUANTITY":      true,
+	"QUANTITY_GREATER_THAN_MAX_QUANTITY":   true,
+	"INVALID_TIME_IN_FORCE":                true,
+	"REJECTED_WOULD_BREACH_MAX_NOTIONAL":   true,
+	"CANNOT_MODIFY_NO_SUCH_ORDER":          true,
+	"REJECTED_MARKET_CLOSED":               true,
+	"REJECTED_FAILED_TO_PROCESS":           true,
+	"INVALID_TAKEPROFIT_PRICE":             true,
+	"INVALID_STOPLOSS_PRICE":               true,
+	"RATE_LIMITED":                         true,
+	"REJECTED_TOO_MANY_OPEN_ORDERS":        true,
+	"REJECTED_OPEN_INTEREST_LIMIT":         true,
+	"MODIFIED":                             true,
 }
 
 // pendingRequest waits for a specific response from the Trade WS.
@@ -219,33 +219,37 @@ func (t *TradeWS) connect(ctx context.Context) error {
 	}
 }
 
-
 func (t *TradeWS) sendAuth(conn *websocket.Conn) error {
-	if t.cfg.HasJWT() {
-		msg := map[string]any{
-			"type": "auth",
-			"params": map[string]any{
-				"jwt": t.cfg.AccessToken,
-			},
-		}
-		return conn.WriteJSON(msg)
-	}
-	creds, err := auth.NewHMACCredentials(t.cfg.PublicKey, t.cfg.SecretKey)
+	msg, err := t.buildAuthMessage()
 	if err != nil {
 		return err
 	}
-	msg := map[string]any{
-		"type": "auth",
-		"params": map[string]any{
-			"hmac": map[string]any{
-				"public_key": creds.PublicKey,
-				"nonce":      creds.Nonce,
-				"unix_ts":    creds.UnixTS,
-				"signature":  creds.Signature,
-			},
-		},
-	}
 	return conn.WriteJSON(msg)
+}
+
+func (t *TradeWS) buildAuthMessage() (map[string]any, error) {
+	params := map[string]any{}
+	if t.cfg.HasJWT() {
+		params["jwt"] = t.cfg.AccessToken
+	} else {
+		creds, err := auth.NewHMACCredentials(t.cfg.PublicKey, t.cfg.SecretKey)
+		if err != nil {
+			return nil, err
+		}
+		params["hmac"] = map[string]any{
+			"public_key": creds.PublicKey,
+			"nonce":      creds.Nonce,
+			"unix_ts":    creds.UnixTS,
+			"signature":  creds.Signature,
+		}
+	}
+	if t.cfg.HasSelectedSubaccount() {
+		params["account_id"] = t.cfg.SelectedSubaccount
+	}
+	return map[string]any{
+		"type":   "auth",
+		"params": params,
+	}, nil
 }
 
 func (t *TradeWS) dispatch(conn *websocket.Conn, data []byte) {

--- a/internal/daemon/trade_ws_test.go
+++ b/internal/daemon/trade_ws_test.go
@@ -1,0 +1,80 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/qfex/cli/internal/config"
+)
+
+func TestBuildAuthMessageWithJWTIncludesAccountIDWhenSelectedSubaccountSet(t *testing.T) {
+	tws := &TradeWS{
+		cfg: &config.Config{
+			AccessToken:        "jwt-token",
+			SelectedSubaccount: "sub-123",
+		},
+	}
+
+	msg, err := tws.buildAuthMessage()
+	if err != nil {
+		t.Fatalf("buildAuthMessage() error = %v", err)
+	}
+
+	params, ok := msg["params"].(map[string]any)
+	if !ok {
+		t.Fatalf("params has type %T, want map[string]any", msg["params"])
+	}
+
+	if got := params["account_id"]; got != "sub-123" {
+		t.Fatalf("account_id = %v, want %q", got, "sub-123")
+	}
+}
+
+func TestBuildAuthMessageWithoutSelectionOmitsAccountID(t *testing.T) {
+	tws := &TradeWS{
+		cfg: &config.Config{
+			AccessToken: "jwt-token",
+		},
+	}
+
+	msg, err := tws.buildAuthMessage()
+	if err != nil {
+		t.Fatalf("buildAuthMessage() error = %v", err)
+	}
+
+	params, ok := msg["params"].(map[string]any)
+	if !ok {
+		t.Fatalf("params has type %T, want map[string]any", msg["params"])
+	}
+
+	if _, ok := params["account_id"]; ok {
+		t.Fatalf("account_id unexpectedly present: %#v", params["account_id"])
+	}
+}
+
+func TestBuildAuthMessageWithHMACIncludesAccountIDWhenSelectedSubaccountSet(t *testing.T) {
+	tws := &TradeWS{
+		cfg: &config.Config{
+			PublicKey:          "public-key",
+			SecretKey:          "secret-key",
+			SelectedSubaccount: "sub-123",
+		},
+	}
+
+	msg, err := tws.buildAuthMessage()
+	if err != nil {
+		t.Fatalf("buildAuthMessage() error = %v", err)
+	}
+
+	params, ok := msg["params"].(map[string]any)
+	if !ok {
+		t.Fatalf("params has type %T, want map[string]any", msg["params"])
+	}
+
+	if got := params["account_id"]; got != "sub-123" {
+		t.Fatalf("account_id = %v, want %q", got, "sub-123")
+	}
+
+	if _, ok := params["hmac"]; !ok {
+		t.Fatalf("hmac auth payload missing")
+	}
+}

--- a/internal/oauth/flow.go
+++ b/internal/oauth/flow.go
@@ -288,7 +288,17 @@ func AuthURLForEnv(env string) string {
 // EmailFromToken decodes the JWT payload and returns the email claim, or an
 // empty string if the token is malformed or the claim is absent.
 func EmailFromToken(accessToken string) string {
-	parts := strings.Split(accessToken, ".")
+	return jwtClaim(accessToken, "email")
+}
+
+// SubFromToken decodes the JWT payload and returns the sub (user ID) claim,
+// or an empty string if the token is malformed or the claim is absent.
+func SubFromToken(accessToken string) string {
+	return jwtClaim(accessToken, "sub")
+}
+
+func jwtClaim(token, key string) string {
+	parts := strings.Split(token, ".")
 	if len(parts) != 3 {
 		return ""
 	}
@@ -296,13 +306,19 @@ func EmailFromToken(accessToken string) string {
 	if err != nil {
 		return ""
 	}
-	var claims struct {
-		Email string `json:"email"`
-	}
+	var claims map[string]json.RawMessage
 	if err := json.Unmarshal(payload, &claims); err != nil {
 		return ""
 	}
-	return claims.Email
+	raw, ok := claims[key]
+	if !ok {
+		return ""
+	}
+	var val string
+	if err := json.Unmarshal(raw, &val); err != nil {
+		return ""
+	}
+	return val
 }
 
 // IsTokenExpired returns true when the JWT access token is expired or within

--- a/internal/oauth/flow_test.go
+++ b/internal/oauth/flow_test.go
@@ -1,0 +1,44 @@
+package oauth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+func TestSubFromTokenReturnsSub(t *testing.T) {
+	token := fakeJWT(t, map[string]any{"sub": "user-abc-123", "email": "a@b.com"})
+	if got := SubFromToken(token); got != "user-abc-123" {
+		t.Fatalf("SubFromToken() = %q, want %q", got, "user-abc-123")
+	}
+}
+
+func TestEmailFromTokenReturnsEmail(t *testing.T) {
+	token := fakeJWT(t, map[string]any{"sub": "user-abc-123", "email": "a@b.com"})
+	if got := EmailFromToken(token); got != "a@b.com" {
+		t.Fatalf("EmailFromToken() = %q, want %q", got, "a@b.com")
+	}
+}
+
+func TestSubFromTokenEmptyOnMalformed(t *testing.T) {
+	if got := SubFromToken("not-a-jwt"); got != "" {
+		t.Fatalf("SubFromToken(malformed) = %q, want empty", got)
+	}
+}
+
+func TestSubFromTokenEmptyWhenClaimMissing(t *testing.T) {
+	token := fakeJWT(t, map[string]any{"email": "a@b.com"})
+	if got := SubFromToken(token); got != "" {
+		t.Fatalf("SubFromToken(no sub) = %q, want empty", got)
+	}
+}
+
+func fakeJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds subaccount-aware authentication for both REST and Trade WebSocket requests, which can change which account executes trades and API actions. Also introduces config persistence and daemon restart behavior, so mis-selection or header propagation bugs could impact user funds and trading context.
> 
> **Overview**
> Adds **subaccount support** across the CLI, including new `qfex account subaccounts` commands to list/create subaccounts, transfer funds between primary/subaccounts, and view/select the active account (with daemon restart when switching).
> 
> Persists `user_id` and `selected_subaccount` in config, prompts users to choose an active account during `qfex login`, and clears these fields on logout.
> 
> Updates authenticated REST requests to optionally include `x-qfex-requested-account-id`, and updates Trade WS auth to include `account_id` when a subaccount is selected; includes new helpers/test seams for daemon restarts plus unit tests covering the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce232ec577e910d18b8861076bbdc820c9bd9918. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->